### PR TITLE
Fix $ZSH_CUSTOM typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ zinit light Aloxaf/fzf-tab
 Clone this repository to your custom directory and then add `fzf-tab` to your plugin list.
 
 ```zsh
-git clone https://github.com/Aloxaf/fzf-tab ~ZSH_CUSTOM/plugins/fzf-tab
+git clone https://github.com/Aloxaf/fzf-tab $ZSH_CUSTOM/plugins/fzf-tab
 ```
 
 ## Prezto


### PR DESCRIPTION
There is a small typo in the README.md that says ~ZSH_CUSTOM instead of $ZSH_CUSTOM for the oh-my-zsh installation command.